### PR TITLE
added Sigma detection response actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,94 @@ BPFView gives you a comprehensive view of the entire process lifecycle:
 
 This granular process tracing provides unparalleled visibility for security monitoring, troubleshooting, and performance analysis.
 
+## Real-Time Response Actions
+
+BPFView can not only detect suspicious activity but also take immediate response actions when threats are identified. These actions are triggered by Sigma rules and provide automated security enforcement with minimal performance impact.
+
+### Available Response Actions
+
+BPFView supports the following response actions that can be specified in Sigma rules:
+
+1. **Process Termination** (`terminate`)
+   - Immediately kills a process when a rule matches
+   - Preserves process exit events in logs for forensic analysis
+
+2. **Network Access Blocking** (`block_network`)
+   - Prevents a process from establishing new network connections
+   - Implemented using eBPF LSM hooks for kernel-level enforcement
+   - Ideal for containing malware or preventing data exfiltration
+
+3. **Child Process Prevention** (`prevent_children`)
+   - Blocks a process from creating new child processes
+   - Stops malware from spawning additional processes
+   - Implemented using eBPF LSM hooks for task creation
+
+### Example Sigma Rules with Response Actions
+
+```yaml
+title: Python3 Process Termination Test
+id: 59fc8b3d-d91a-4a3c-8f87-c65fe76371be
+status: test
+description: Detects python3 execution and terminates the process
+author: Test Author
+date: 2025/04/18
+logsource:
+  product: linux
+  category: process_creation
+detection:
+  selection:
+    ProcessName|contains:
+      - python3
+    Image|endswith:
+      - /python3
+      - /python3.9
+  condition: selection
+actions:
+  - type: terminate
+level: info
+```
+
+```yaml
+title: Python3 Process Network Block Test
+id: 79043c45-6176-4556-8e23-98a7c3e22b72
+status: test
+description: Detects python3 execution and blocks network access
+author: Test Author
+date: 2025/04/18
+logsource:
+  product: linux
+  category: process_creation
+detection:
+  selection:
+    ProcessName|contains:
+      - python3
+    Image|endswith:
+      - /python3
+  condition: selection
+actions:
+  - type: block_network
+level: info
+```
+
+### Command Line Use
+
+To enable response actions, simply run BPFView with the Sigma rules directory:
+
+```bash
+# Enable Sigma detection with response actions
+sudo bpfview --sigma ./sigma
+```
+
+### Implementation Details
+
+BPFView's response actions are implemented using a hybrid approach:
+- Process termination is handled directly in userspace for maximum reliability
+- Network and process creation blocking are enforced at the kernel level using eBPF LSM hooks
+- All actions are logged with detailed context for auditing and forensic purposes
+
+Response actions provide a powerful way to automatically contain threats as soon as they're detected, significantly reducing the time between detection and response in your security operations.
+
+
 ## Command Line Interface
 
 BPFView offers comprehensive filtering capabilities that can be combined to precisely target what you want to monitor:

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -24,6 +24,7 @@
 #define EVENT_DNS          6   // DNS query or response
 #define EVENT_TLS          7   // TLS handshake events
 #define EVENT_PROCESS_FORK 8   // Process creation via fork/clone
+#define EVENT_RESPONSE     9   // Response action taken
 
 // DNS operation flags
 #define DNS_QUERY    1   // Outbound DNS query
@@ -162,6 +163,7 @@ struct process_restrictions {
 } __attribute__((packed));
 
 struct event {
+    __u32 event_type;    
     __u32 pid;
     __u32 ppid; 
     char comm[16];

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -42,6 +42,9 @@
 #define TLS_CLIENT_HELLO    1
 #define TLS_SERVER_HELLO    2
 
+// Response action flags
+#define BLOCK_NETWORK       0x1
+#define PREVENT_CHILDREN    0x2
 
 // Socket info for tracking process info
 struct sock_info {
@@ -151,5 +154,20 @@ struct tls_event {
     __u16 data_len;
     unsigned char data[MAX_TLS_DATA];
 } __attribute__((packed));
+
+struct process_restrictions {
+    __u32 flags;
+    __u32 padding;
+    __u64 timestamp;
+} __attribute__((packed));
+
+struct event {
+    __u32 pid;
+    __u32 ppid; 
+    char comm[16];
+    __u32 action_taken;
+    __u32 blocked_syscall;
+    __u32 restriction_flags;
+};
 
 #endif /* __COMMON_H */

--- a/bpf/response.c
+++ b/bpf/response.c
@@ -1,0 +1,90 @@
+// bpf/response.c
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "common.h"
+
+// Map to track restricted processes
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 10000);
+    __type(key, pid_t);
+    __type(value, struct process_restrictions);
+} restricted_procs SEC(".maps");
+
+// Ringbuffer for events
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 256 * 1024);
+} events SEC(".maps");
+
+static void emit_event(pid_t pid, __u32 action, __u32 flags) {
+    struct event *e;
+    e = bpf_ringbuf_reserve(&events, sizeof(*e), 0);
+    if (!e) return;
+    
+    e->pid = pid;
+    e->ppid = 0;
+    e->action_taken = action;
+    e->blocked_syscall = 0;
+    e->restriction_flags = flags;
+    bpf_get_current_comm(&e->comm, sizeof(e->comm));
+    
+    bpf_ringbuf_submit(e, 0);
+}
+
+SEC("lsm/bprm_check_security")
+int check_exec(struct linux_binprm *bprm) {
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid_t pid = pid_tgid >> 32;
+    
+    struct process_restrictions *restrictions = bpf_map_lookup_elem(&restricted_procs, &pid);
+    if (!restrictions) {
+        return 0;
+    }
+
+    if (restrictions->flags & PREVENT_CHILDREN) {
+        emit_event(pid, 1, restrictions->flags);
+        return -1;
+    }
+    
+    return 0;
+}
+
+SEC("lsm/task_alloc")
+int check_task_alloc(struct task_struct *task, unsigned long clone_flags) {
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid_t pid = pid_tgid >> 32;
+
+    struct process_restrictions *restrictions = bpf_map_lookup_elem(&restricted_procs, &pid);
+    if (!restrictions) {
+        return 0;
+    }
+
+    if (restrictions->flags & PREVENT_CHILDREN) {
+        emit_event(pid, 3, restrictions->flags);  // Different event type for task_alloc
+        return -1;
+    }
+
+    return 0;
+}
+
+SEC("lsm/socket_connect")
+int check_connect(struct socket *sock, struct sockaddr *address, int addrlen) {
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    pid_t pid = pid_tgid >> 32;
+    
+    struct process_restrictions *restrictions = bpf_map_lookup_elem(&restricted_procs, &pid);
+    if (!restrictions) {
+        return 0;
+    }
+
+    if (restrictions->flags & BLOCK_NETWORK) {
+        emit_event(pid, 2, restrictions->flags);
+        return -1;
+    }
+    
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/bpf/response.c
+++ b/bpf/response.c
@@ -23,6 +23,7 @@ static void emit_event(pid_t pid, __u32 action, __u32 flags) {
     e = bpf_ringbuf_reserve(&events, sizeof(*e), 0);
     if (!e) return;
     
+    e->event_type = EVENT_RESPONSE;
     e->pid = pid;
     e->ppid = 0;
     e->action_taken = action;
@@ -88,3 +89,4 @@ int check_connect(struct socket *sock, struct sockaddr *address, int addrlen) {
 }
 
 char LICENSE[] SEC("license") = "GPL";
+

--- a/response.go
+++ b/response.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// ResponseManager handles applying restrictions to processes
+type ResponseManager struct {
+	objs *responseObjects
+}
+
+// NewResponseManager creates a new ResponseManager
+func NewResponseManager(objs *responseObjects) *ResponseManager {
+	return &ResponseManager{
+		objs: objs,
+	}
+}
+
+// ApplyRestrictions applies the specified restrictions to a process
+func (rm *ResponseManager) ApplyRestrictions(pid uint32, flags uint32) error {
+	restrictions := struct {
+		Flags     uint32
+		Padding   uint32
+		Timestamp uint64
+	}{
+		Flags:     flags,
+		Timestamp: uint64(time.Now().Unix()),
+	}
+
+	// Apply restrictions
+	if err := rm.objs.RestrictedProcs.Put(pid, &restrictions); err != nil {
+		return fmt.Errorf("putting restrictions: %w", err)
+	}
+
+	// Verify they were applied
+	var stored struct {
+		Flags     uint32
+		Padding   uint32
+		Timestamp uint64
+	}
+	if err := rm.objs.RestrictedProcs.Lookup(pid, &stored); err != nil {
+		return fmt.Errorf("verifying restrictions: %w", err)
+	}
+
+	globalLogger.Debug("response", "Applied restrictions to PID %d: Flags=0x%x", pid, stored.Flags)
+	return nil
+}
+
+// RemoveRestrictions removes all restrictions from a process
+func (rm *ResponseManager) RemoveRestrictions(pid uint32) error {
+	if err := rm.objs.RestrictedProcs.Delete(pid); err != nil {
+		return fmt.Errorf("removing restrictions: %w", err)
+	}
+
+	globalLogger.Debug("response", "Removed all restrictions from PID %d", pid)
+	return nil
+}
+
+// GetRestrictions gets the current restrictions for a process
+func (rm *ResponseManager) GetRestrictions(pid uint32) (uint32, error) {
+	var restrictions struct {
+		Flags     uint32
+		Padding   uint32
+		Timestamp uint64
+	}
+
+	if err := rm.objs.RestrictedProcs.Lookup(pid, &restrictions); err != nil {
+		return 0, fmt.Errorf("looking up restrictions: %w", err)
+	}
+
+	return restrictions.Flags, nil
+}

--- a/types/events.go
+++ b/types/events.go
@@ -15,12 +15,33 @@ const (
 	EVENT_DNS          = 6
 	EVENT_TLS          = 7
 	EVENT_PROCESS_FORK = 8
+	EVENT_RESPONSE     = 9
 )
 
 // Flow direction constants matching BPF program
 const (
 	FLOW_INGRESS = 1
 	FLOW_EGRESS  = 2
+)
+
+// bit flags for capabilities
+const (
+	BLOCK_NETWORK    = 0x1
+	PREVENT_CHILDREN = 0x2
+)
+
+// Response action types - these match the Sigma rule YAML syntax
+const (
+	ACTION_BLOCK_NETWORK    = "block_network"
+	ACTION_PREVENT_CHILDREN = "prevent_children"
+	ACTION_TERMINATE        = "terminate"
+)
+
+// Response action notification types (from response events)
+const (
+	RESPONSE_ACTION_EXEC_BLOCKED    = 1 // matches emit_event(pid, 1, flags)
+	RESPONSE_ACTION_NETWORK_BLOCKED = 2 // matches emit_event(pid, 2, flags)
+	RESPONSE_ACTION_TASK_BLOCKED    = 3 // matches emit_event(pid, 3, flags)
 )
 
 // CRITICAL: The following struct layouts must exactly match BPF programs.
@@ -209,4 +230,5 @@ type SigmaMatch struct {
 	RuleReferences  []string
 	RuleTags        []string
 	DetectionSource string // "dns_query" or "network_connection" or "process_creation"
+	ResponseActions []string
 }


### PR DESCRIPTION
This PR adds real-time response capabilities to BPFView's Sigma rule detection system. It enables automatic enforcement actions in response to sigma matches.

Added features:
- Three response action types for Sigma rules:
  - `terminate`: Kill processes when rules match (implemented in userspace)
  - `block_network`: Prevent network connections (implemented with eBPF LSM hooks)
  - `prevent_children`: Block child process creation (implemented with eBPF LSM hooks)
- New BPF program (response.c) using Linux Security Module hooks
- ResponseManager for applying/removing process restrictions
- Event system for tracking applied restrictions and enforcement actions
- Example Sigma rules demonstrating each response action type
- Documentation in README.md explaining the feature

Implementation details:
- Process termination implemented directly in userspace for reliability
- Network and process creation blocking enforced at kernel level using BPF LSM hooks
- All response actions are logged
- Minimized performance impact by using efficient BPF map lookups

This feature reduces time between detection and containment, allowing BPFView to not only monitor system activity but also automatically respond to threats according to defined security policies.