### PR TITLE
process information levels

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -92,6 +92,31 @@ var (
 		},
 	)
 
+	processInfoDurations = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "bpfview_process_info_duration_seconds",
+			Help:    "Time spent collecting process information by level",
+			Buckets: prometheus.ExponentialBuckets(0.0001, 2, 10),
+		},
+		[]string{"level"}, // level will be "minimal", "basic", "full"
+	)
+
+	processInfoLevelStats = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bpfview_process_info_level_total",
+			Help: "Number of process info collections by level",
+		},
+		[]string{"level", "result"}, // level will be minimal/basic/full, result success/failure
+	)
+
+	processInfoProcReads = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bpfview_process_info_proc_reads",
+			Help: "Number of /proc reads by process info level",
+		},
+		[]string{"level", "file"}, // track which files we're reading at each level
+	)
+
 	excludedEventsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "bpfview_excluded_events_total",

--- a/process.go
+++ b/process.go
@@ -906,7 +906,7 @@ func CompleteProcessInfo(info *types.ProcessInfo, level types.ProcessInfoLevel) 
 	}
 
 	// Minimal level - always do these since they're cheap
-	if info.Username == "" && info.UID > 0 {
+	if info.Username == "" {
 		info.Username = GetUsernameFromUID(info.UID)
 		processInfoLevelStats.WithLabelValues("minimal", "success").Inc()
 	}

--- a/types/events.go
+++ b/types/events.go
@@ -45,6 +45,14 @@ const (
 	RESPONSE_ACTION_TASK_BLOCKED    = 3 // matches emit_event(pid, 3, flags)
 )
 
+type ProcessInfoLevel int
+
+const (
+	ProcessLevelMinimal ProcessInfoLevel = iota
+	ProcessLevelBasic
+	ProcessLevelFull
+)
+
 // CRITICAL: The following struct layouts must exactly match BPF programs.
 // Any changes require coordinated updates to the corresponding BPF code.
 


### PR DESCRIPTION
this PR introduces the concept of process information levels.  We now collect a different quantity of information from user land at each different process information level:

Minimal:

- Use primary what we get from BPF
- Also lookup process start time via os.Stat /proc/pid, otherwise nothing from /proc

Basic:

- Also try to lookup cwd and cmdline from /proc

Full:

- Lookup everything else, including env variables, container id, parent process info, etc 