### PR TITLE
Add process exclusion support with metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Response actions provide a powerful way to automatically contain threats as soon
 
 BPFView offers comprehensive filtering capabilities that can be combined to precisely target what you want to monitor:
 
-### Process Filtering
+### Process Filtering (Selective Inclusion)
 ```bash
 # Filter by command name
 sudo bpfview --comm nginx,php-fpm
@@ -626,6 +626,43 @@ sudo bpfview --format json  # Use JSON format (default: text)
 sudo bpfview --format json-ecs  # Use Elastic Common Schema format
 sudo bpfview --format gelf  # Use Graylog Extended Log Format
 ```
+
+### Process Exclusions (Selective Exclusion)
+
+BPFView allows you to exclude specific processes from monitoring, which is useful for filtering out high-volume system processes that aren't relevant to your analysis:
+
+```bash
+# Exclude processes by command name
+sudo bpfview --exclude-comm "chronyd,bpfview"
+
+# Exclude processes by executable path
+sudo bpfview --exclude-exe-path "/usr/sbin/"
+
+# Exclude processes by username
+sudo bpfview --exclude-user "nobody,systemd-resolve" 
+
+# Exclude processes by container ID
+sudo bpfview --exclude-container "3f4552dfc342"
+
+# Combine exclusions with inclusions
+sudo bpfview --comm nginx --exclude-comm "chronyd,sshd"
+```
+
+Exclusions are evaluated during event processing and provide a high-performance way to filter out noisy system processes. When exclusions are enabled, BPFView reports metrics about excluded processes that can be viewed via the Prometheus endpoint.
+
+## Performance Optimization
+
+BPFView is designed to operate efficiently with minimal performance impact, but can be further optimized for specific environments and high-volume workloads.
+
+For detailed information about performance features, tuning options, and monitoring capabilities, see the [Performance Optimization Guide](PERFORMANCE.md).
+
+Key optimization features include:
+- Process exclusion filters to ignore high-volume system processes
+- Process information level control to reduce /proc filesystem access
+- Cache size management for memory optimization
+- Container-specific optimizations
+
+These features allow BPFView to scale from development environments to high-volume production servers while maintaining low overhead.
 
 ## Technical Implementation
 

--- a/dns.go
+++ b/dns.go
@@ -44,6 +44,11 @@ func handleDNSEvent(event *types.BPFDNSRawEvent) error {
 		}
 	}
 
+	// Early exclusion check before any more expensive operations
+	if globalExcludeEngine != nil && globalExcludeEngine.ShouldExclude(processInfo) {
+		return nil
+	}
+
 	// Clean up process names
 	comm := string(bytes.TrimRight(event.Comm[:], "\x00"))
 	parentComm := string(bytes.TrimRight(event.ParentComm[:], "\x00"))

--- a/exclusions.go
+++ b/exclusions.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jnesss/bpfview/types"
+)
+
+// ExclusionConfig holds all exclusion patterns
+type ExclusionConfig struct {
+	CommNames    []string
+	ExePaths     []string
+	UserNames    []string
+	ContainerIDs []string
+}
+
+// ExclusionState tracks process tree state for exclusions
+type ExclusionState struct {
+	excludedPIDs map[uint32]struct{} // PIDs that matched exclusion rules
+	includedPIDs map[uint32]struct{} // PIDs explicitly included due to tree tracking
+	mu           sync.RWMutex
+}
+
+func NewExclusionState() *ExclusionState {
+	return &ExclusionState{
+		excludedPIDs: make(map[uint32]struct{}),
+		includedPIDs: make(map[uint32]struct{}),
+	}
+}
+
+// ExclusionEngine handles fast-path exclusion of high-volume processes
+type ExclusionEngine struct {
+	config ExclusionConfig
+	mu     sync.RWMutex
+
+	// Pattern matchers
+	commMatcher      *PatternMatcher
+	exePathMatcher   *PatternMatcher
+	userMatcher      *PatternMatcher
+	containerMatcher *PatternMatcher
+
+	// Tree tracking
+	state        *ExclusionState
+	treeTracking bool
+}
+
+func NewExclusionEngine(config ExclusionConfig, enableTreeTracking bool) *ExclusionEngine {
+	e := &ExclusionEngine{
+		config:       config,
+		treeTracking: enableTreeTracking,
+		state:        NewExclusionState(),
+	}
+
+	// Initialize pattern matchers
+	e.commMatcher = NewPatternMatcher(config.CommNames)
+	e.exePathMatcher = NewPatternMatcher(config.ExePaths)
+	e.userMatcher = NewPatternMatcher(config.UserNames)
+	e.containerMatcher = NewPatternMatcher(config.ContainerIDs)
+
+	return e
+}
+
+// ShouldExclude performs pattern-aware exclusion check with metrics
+func (e *ExclusionEngine) ShouldExclude(info *types.ProcessInfo) bool {
+	start := time.Now()
+	defer func() {
+		exclusionLatency.WithLabelValues("process").Observe(time.Since(start).Seconds())
+	}()
+
+	// Check tree tracking first
+	if e.treeTracking {
+		e.state.mu.RLock()
+		// If parent is included, include this process
+		if _, included := e.state.includedPIDs[info.PPID]; included {
+			e.state.includedPIDs[info.PID] = struct{}{}
+			e.state.mu.RUnlock()
+			return false
+		}
+		// If parent is excluded, exclude this process
+		if _, excluded := e.state.excludedPIDs[info.PPID]; excluded {
+			e.state.excludedPIDs[info.PID] = struct{}{}
+			e.state.mu.RUnlock()
+			return true
+		}
+		e.state.mu.RUnlock()
+	}
+
+	excluded := false
+
+	// Check comm name (usually fastest)
+	if e.commMatcher.Matches(info.Comm) {
+		excludedEventsTotal.WithLabelValues("process", "comm", info.Comm).Inc()
+		excluded = true
+	}
+
+	if !excluded && info.ExePath != "" {
+		// Check executable path
+		if e.exePathMatcher.Matches(info.ExePath) {
+			excludedEventsTotal.WithLabelValues("process", "exe_path", info.ExePath).Inc()
+			excluded = true
+		}
+	}
+
+	if !excluded && info.Username != "" {
+		// Check executable path
+		if e.userMatcher.Matches(info.Username) {
+			excludedEventsTotal.WithLabelValues("process", "username", info.Username).Inc()
+			excluded = true
+		}
+	}
+
+	if !excluded && info.ContainerID != "" {
+		// Check executable path
+		if e.containerMatcher.Matches(info.ContainerID) {
+			excludedEventsTotal.WithLabelValues("process", "container", info.ContainerID).Inc()
+			excluded = true
+		}
+	}
+
+	if excluded {
+		// Track exclusion in tree state if needed
+		if e.treeTracking {
+			e.state.mu.Lock()
+			e.state.excludedPIDs[info.PID] = struct{}{}
+			e.state.mu.Unlock()
+		}
+
+		// Increment overall statistics
+		size := len(info.Comm) + len(info.ExePath) + len(info.Username) +
+			len(info.ContainerID) + 64 // Base struct size
+		excludedEventSize.WithLabelValues("process").Observe(float64(size))
+		exclusionMatchRate.WithLabelValues("process").Observe(1.0)
+	}
+
+	return excluded
+}
+
+// HandleProcessExit cleans up tree tracking state
+func (e *ExclusionEngine) HandleProcessExit(pid uint32) {
+	if !e.treeTracking {
+		return
+	}
+
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+
+	delete(e.state.excludedPIDs, pid)
+	delete(e.state.includedPIDs, pid)
+}
+
+// MarkProcessIncluded explicitly includes a process and its children
+func (e *ExclusionEngine) MarkProcessIncluded(pid uint32) {
+	if !e.treeTracking {
+		return
+	}
+
+	e.state.mu.Lock()
+	defer e.state.mu.Unlock()
+
+	e.state.includedPIDs[pid] = struct{}{}
+	delete(e.state.excludedPIDs, pid) // Remove from excluded if present
+}
+
+// UpdateConfig allows dynamic updates of exclusion patterns with pattern matching
+func (e *ExclusionEngine) UpdateConfig(config ExclusionConfig) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.config = config
+
+	// Rebuild pattern matchers
+	e.commMatcher = NewPatternMatcher(config.CommNames)
+	e.exePathMatcher = NewPatternMatcher(config.ExePaths)
+	e.userMatcher = NewPatternMatcher(config.UserNames)
+	e.containerMatcher = NewPatternMatcher(config.ContainerIDs)
+}
+
+func (e *ExclusionEngine) reportMetrics() {
+	// Update pattern counts
+	exclusionPatternCount.WithLabelValues("comm").Set(float64(len(e.config.CommNames)))
+	exclusionPatternCount.WithLabelValues("exe_path").Set(float64(len(e.config.ExePaths)))
+	exclusionPatternCount.WithLabelValues("username").Set(float64(len(e.config.UserNames)))
+	exclusionPatternCount.WithLabelValues("container").Set(float64(len(e.config.ContainerIDs)))
+
+	// For now we don't have a pattern matching cache
+	// Future: Add caching if needed for performance
+}
+
+func (e *ExclusionEngine) recordExcludedEventSize(eventType string, size int) {
+	excludedEventSize.WithLabelValues(eventType).Observe(float64(size))
+}

--- a/filter.go
+++ b/filter.go
@@ -24,6 +24,12 @@ type FilterConfig struct {
 	TrackTree       bool
 	HashBinaries    bool
 
+	// Process exclusions
+	ExcludeComm      []string
+	ExcludeExePath   []string
+	ExcludeUser      []string
+	ExcludeContainer []string
+
 	// Network filters
 	SrcIPs    []string
 	DstIPs    []string

--- a/network.go
+++ b/network.go
@@ -84,6 +84,11 @@ func handleNetworkEvent(event *types.NetworkEvent) {
 		}
 	}
 
+	// Early exclusion check before any more expensive operations
+	if globalExcludeEngine != nil && globalExcludeEngine.ShouldExclude(processInfo) {
+		return
+	}
+
 	// Clean up process names
 	timer.StartPhase("prepare_message")
 	comm := string(bytes.TrimRight(event.Comm[:], "\x00"))

--- a/pattern_matching.go
+++ b/pattern_matching.go
@@ -1,0 +1,106 @@
+// pattern_matching.go
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type PatternMatcher struct {
+	mu sync.RWMutex
+
+	// Exact matches (fastest)
+	exactMatches map[string]struct{}
+
+	// Glob patterns
+	globPatterns []string
+
+	// Prefix matches
+	prefixMatches []string
+}
+
+func NewPatternMatcher(patterns []string) *PatternMatcher {
+	pm := &PatternMatcher{
+		exactMatches: make(map[string]struct{}),
+	}
+
+	for _, pattern := range patterns {
+		if strings.ContainsAny(pattern, "*?[]") {
+			// Glob pattern
+			pm.globPatterns = append(pm.globPatterns, pattern)
+		} else if strings.HasSuffix(pattern, "/") {
+			// Prefix match (for paths)
+			pm.prefixMatches = append(pm.prefixMatches, strings.TrimSuffix(pattern, "/"))
+		} else {
+			// Exact match
+			pm.exactMatches[pattern] = struct{}{}
+		}
+	}
+
+	return pm
+}
+
+func (pm *PatternMatcher) Matches(s string) bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	// Try exact match first (fastest)
+	if _, ok := pm.exactMatches[s]; ok {
+		return true
+	}
+
+	// Try prefix matches next
+	for _, prefix := range pm.prefixMatches {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+
+	// Try glob patterns last (most expensive)
+	for _, pattern := range pm.globPatterns {
+		matched, err := filepath.Match(pattern, s)
+		if err == nil && matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (pm *PatternMatcher) Add(pattern string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if strings.ContainsAny(pattern, "*?[]") {
+		pm.globPatterns = append(pm.globPatterns, pattern)
+	} else if strings.HasSuffix(pattern, "/") {
+		pm.prefixMatches = append(pm.prefixMatches, strings.TrimSuffix(pattern, "/"))
+	} else {
+		pm.exactMatches[pattern] = struct{}{}
+	}
+}
+
+func (pm *PatternMatcher) Remove(pattern string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if strings.ContainsAny(pattern, "*?[]") {
+		for i, p := range pm.globPatterns {
+			if p == pattern {
+				pm.globPatterns = append(pm.globPatterns[:i], pm.globPatterns[i+1:]...)
+				break
+			}
+		}
+	} else if strings.HasSuffix(pattern, "/") {
+		trimmed := strings.TrimSuffix(pattern, "/")
+		for i, p := range pm.prefixMatches {
+			if p == trimmed {
+				pm.prefixMatches = append(pm.prefixMatches[:i], pm.prefixMatches[i+1:]...)
+				break
+			}
+		}
+	} else {
+		delete(pm.exactMatches, pattern)
+	}
+}

--- a/tls.go
+++ b/tls.go
@@ -94,6 +94,11 @@ func handleTLSEvent(event *types.BPFTLSEvent) {
 		}
 	}
 
+	// Early exclusion check before any more expensive operations
+	if globalExcludeEngine != nil && globalExcludeEngine.ShouldExclude(processInfo) {
+		return
+	}
+
 	// Clean up process names
 	comm := string(bytes.TrimRight(event.Comm[:], "\x00"))
 	parentComm := string(bytes.TrimRight(event.ParentComm[:], "\x00"))

--- a/tools/phase-stats/main.go
+++ b/tools/phase-stats/main.go
@@ -10,6 +10,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
+	"text/tabwriter"
+	"os"
 )
 
 type MetricSample struct {
@@ -18,15 +21,38 @@ type MetricSample struct {
 	Value  float64
 }
 
+type ExclusionStats struct {
+	Total          float64
+	ByType         map[string]map[string]float64 // rule_type -> pattern -> count
+	LatencyAvg     float64
+	LatencyMax     float64
+	PatternCount   map[string]float64
+	ExcludedEvents map[string]float64
+}
+
 func main() {
 	metricsURL := flag.String("url", "http://localhost:2112/metrics", "URL to fetch Prometheus metrics from")
 	handler := flag.String("handler", "", "Handler to analyze (process_exec, process_fork, process_exit, dns_event, network_event, tls_event)")
 	listHandlers := flag.Bool("list", false, "List all available handlers")
 	all := flag.Bool("all", false, "Show stats for all handlers")
+	showExclusions := flag.Bool("exclusions", false, "Show detailed exclusion statistics")
+	refreshInterval := flag.Int("refresh", 0, "Refresh interval in seconds (0 for one-time)")
 	flag.Parse()
 
+	if *refreshInterval > 0 {
+		for {
+			clearScreen()
+			analyzeMetrics(*metricsURL, *handler, *listHandlers, *all, *showExclusions)
+			time.Sleep(time.Duration(*refreshInterval) * time.Second)
+		}
+	} else {
+		analyzeMetrics(*metricsURL, *handler, *listHandlers, *all, *showExclusions)
+	}
+}
+
+func analyzeMetrics(metricsURL string, handler string, listHandlers bool, all bool, showExclusions bool) {
 	// Fetch metrics
-	metrics, err := fetchMetrics(*metricsURL)
+	metrics, err := fetchMetrics(metricsURL)
 	if err != nil {
 		fmt.Printf("Error fetching metrics: %v\n", err)
 		return
@@ -35,7 +61,7 @@ func main() {
 	// Get handlers
 	handlers := extractHandlers(metrics)
 
-	if *listHandlers {
+	if listHandlers {
 		fmt.Println("Available handlers:")
 		for _, h := range handlers {
 			fmt.Printf("  - %s\n", h)
@@ -43,27 +69,309 @@ func main() {
 		return
 	}
 
-	if *all {
+	// Show general metrics first
+	if showExclusions {
+		printGeneralStats(metrics)
+	}
+
+	if all {
 		for _, h := range handlers {
 			printHandlerStats(h, metrics)
+		}
+		if showExclusions {
+			printExclusionStats(metrics)
 		}
 		return
 	}
 
-	if *handler == "" {
+	if handler == "" && !showExclusions {
 		fmt.Println("Please specify a handler with -handler or use -list to see available handlers")
 		return
 	}
 
-	if !contains(handlers, *handler) {
-		fmt.Printf("Handler %s not found. Available handlers:\n", *handler)
-		for _, h := range handlers {
-			fmt.Printf("  - %s\n", h)
+	if handler != "" {
+		if !contains(handlers, handler) {
+			fmt.Printf("Handler %s not found. Available handlers:\n", handler)
+			for _, h := range handlers {
+				fmt.Printf("  - %s\n", h)
+			}
+			return
 		}
-		return
+		printHandlerStats(handler, metrics)
 	}
 
-	printHandlerStats(*handler, metrics)
+	if showExclusions {
+		printExclusionStats(metrics)
+	}
+}
+
+func printGeneralStats(metrics []MetricSample) {
+	totalEvents := make(map[string]float64)
+	for _, m := range metrics {
+		if m.Name == "bpfview_events_total" {
+			if eventType, ok := m.Labels["event_type"]; ok {
+				totalEvents[eventType] = m.Value
+			}
+		}
+	}
+
+	fmt.Printf("\nGeneral Statistics\n")
+	fmt.Printf("===================\n")
+	
+	if len(totalEvents) > 0 {
+		fmt.Printf("Total Events Processed:\n")
+		var total float64
+		for eventType, count := range totalEvents {
+			fmt.Printf("  ├─ %s: %.0f\n", eventType, count)
+			total += count
+		}
+		fmt.Printf("  └─ Total: %.0f\n", total)
+	}
+	
+	// Add resource usage if available
+	var goroutines, memory float64
+	for _, m := range metrics {
+		if m.Name == "bpfview_resource_usage" {
+			if resource, ok := m.Labels["resource"]; ok {
+				if resource == "goroutines" {
+					goroutines = m.Value
+				} else if resource == "memory_bytes" {
+					memory = m.Value
+				}
+			}
+		}
+	}
+	
+	if goroutines > 0 || memory > 0 {
+		fmt.Printf("\nResource Usage:\n")
+		if goroutines > 0 {
+			fmt.Printf("  ├─ Goroutines: %.0f\n", goroutines)
+		}
+		if memory > 0 {
+			fmt.Printf("  └─ Memory: %.2f MB\n", memory/1024/1024)
+		}
+	}
+}
+
+func printExclusionStats(metrics []MetricSample) {
+	stats := collectExclusionStats(metrics)
+
+	fmt.Printf("\nExclusion Statistics\n")
+	fmt.Printf("===================\n")
+	fmt.Printf("Total Exclusions: %.0f\n", stats.Total)
+
+	if len(stats.ByType) > 0 {
+		fmt.Printf("\nExclusions by Type:\n")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintf(w, "  Rule Type\tPattern\tCount\t\n")
+		fmt.Fprintf(w, "  ---------\t-------\t-----\t\n")
+		
+		// Sort rule types for consistent output
+		ruleTypes := make([]string, 0, len(stats.ByType))
+		for ruleType := range stats.ByType {
+			ruleTypes = append(ruleTypes, ruleType)
+		}
+		sort.Strings(ruleTypes)
+		
+		for _, ruleType := range ruleTypes {
+			patterns := stats.ByType[ruleType]
+			
+			// Sort patterns for consistent output
+			patternList := make([]string, 0, len(patterns))
+			for pattern := range patterns {
+				patternList = append(patternList, pattern)
+			}
+			sort.Strings(patternList)
+			
+			for _, pattern := range patternList {
+				count := patterns[pattern]
+				fmt.Fprintf(w, "  %s\t%s\t%.0f\t\n", ruleType, pattern, count)
+			}
+		}
+		w.Flush()
+	}
+
+	if len(stats.PatternCount) > 0 {
+		fmt.Printf("\nActive Exclusion Patterns:\n")
+		for typ, count := range stats.PatternCount {
+			fmt.Printf("  ├─ %s: %.0f\n", typ, count)
+		}
+	}
+
+	// Show histogram of exclusion latency if available
+	var latencyBuckets = make(map[string]float64)
+	for _, m := range metrics {
+		if m.Name == "bpfview_exclusion_latency_seconds_bucket" {
+			if le, ok := m.Labels["le"]; ok {
+				latencyBuckets[le] = m.Value
+			}
+		}
+	}
+	
+	if len(latencyBuckets) > 0 {
+		fmt.Printf("\nExclusion Latency Distribution (microseconds):\n")
+		printHistogram(latencyBuckets, 1000000) // Convert to microseconds
+	}
+
+	if stats.LatencyAvg > 0 {
+		fmt.Printf("\nLatency Statistics:\n")
+		fmt.Printf("  ├─ Average: %.3f μs\n", stats.LatencyAvg*1000000)
+		fmt.Printf("  └─ Maximum: %.3f μs\n", stats.LatencyMax*1000000)
+	}
+
+	if len(stats.ExcludedEvents) > 0 {
+		fmt.Printf("\nExcluded Events by Size:\n")
+		fmt.Printf("  ├─ Average Size: %.0f bytes\n", stats.ExcludedEvents["avg"])
+		fmt.Printf("  └─ Total Events: %.0f\n", stats.ExcludedEvents["count"])
+	}
+}
+
+func printHistogram(buckets map[string]float64, multiplier float64) {
+	// Sort bucket boundaries
+	boundaries := make([]float64, 0, len(buckets))
+	for le := range buckets {
+		if le != "+Inf" {
+			val, err := strconv.ParseFloat(le, 64)
+			if err == nil {
+				boundaries = append(boundaries, val)
+			}
+		}
+	}
+	sort.Float64s(boundaries)
+	
+	// Calculate bucket values (not cumulative)
+	values := make([]float64, len(boundaries)+1)
+	prevCount := 0.0
+	
+	for i, boundary := range boundaries {
+		leStr := strconv.FormatFloat(boundary, 'f', -1, 64)
+		count := buckets[leStr]
+		values[i] = count - prevCount
+		prevCount = count
+	}
+	
+	// Inf bucket
+	if infCount, ok := buckets["+Inf"]; ok {
+		values[len(values)-1] = infCount - prevCount
+	}
+	
+	// Print histogram
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "  Range\tCount\tHistogram\t\n")
+	fmt.Fprintf(w, "  -----\t-----\t---------\t\n")
+	
+	maxCount := 0.0
+	for _, v := range values {
+		if v > maxCount {
+			maxCount = v
+		}
+	}
+	
+	// Print first bucket
+	if len(boundaries) > 0 {
+		histStr := generateHistBar(values[0], maxCount, 40)
+		fmt.Fprintf(w, "  < %.2f\t%.0f\t%s\t\n", boundaries[0]*multiplier, values[0], histStr)
+	}
+	
+	// Print middle buckets
+	for i := 0; i < len(boundaries)-1; i++ {
+		histStr := generateHistBar(values[i+1], maxCount, 40)
+		fmt.Fprintf(w, "  %.2f - %.2f\t%.0f\t%s\t\n", 
+			boundaries[i]*multiplier, 
+			boundaries[i+1]*multiplier, 
+			values[i+1], 
+			histStr)
+	}
+	
+	// Print infinity bucket
+	if len(boundaries) > 0 {
+		histStr := generateHistBar(values[len(values)-1], maxCount, 40)
+		fmt.Fprintf(w, "  > %.2f\t%.0f\t%s\t\n", 
+			boundaries[len(boundaries)-1]*multiplier, 
+			values[len(values)-1], 
+			histStr)
+	}
+	
+	w.Flush()
+}
+
+func generateHistBar(value, max float64, width int) string {
+	if max == 0 {
+		return ""
+	}
+	chars := int(value / max * float64(width))
+	if chars < 1 && value > 0 {
+		chars = 1
+	}
+	return strings.Repeat("█", chars)
+}
+
+func collectExclusionStats(metrics []MetricSample) ExclusionStats {
+	stats := ExclusionStats{
+		ByType:         make(map[string]map[string]float64),
+		PatternCount:   make(map[string]float64),
+		ExcludedEvents: make(map[string]float64),
+	}
+
+	for _, m := range metrics {
+		switch {
+		case m.Name == "bpfview_excluded_events_total":
+			stats.Total += m.Value
+			
+			ruleType, hasRuleType := m.Labels["rule_type"]
+			pattern, hasPattern := m.Labels["pattern"]
+			
+			if hasRuleType && hasPattern {
+				if _, ok := stats.ByType[ruleType]; !ok {
+					stats.ByType[ruleType] = make(map[string]float64)
+				}
+				stats.ByType[ruleType][pattern] = m.Value
+			}
+
+		case m.Name == "bpfview_exclusion_latency_seconds_sum":
+			// Calculate average latency
+			var count float64
+			for _, m2 := range metrics {
+				if m2.Name == "bpfview_exclusion_latency_seconds_count" && 
+				   m2.Labels["pattern_type"] == m.Labels["pattern_type"] {
+					count = m2.Value
+					break
+				}
+			}
+			if count > 0 {
+				stats.LatencyAvg = m.Value / count
+			}
+
+		case m.Name == "bpfview_exclusion_latency_seconds_bucket":
+			// Find max latency from histogram buckets
+			if le, ok := m.Labels["le"]; ok && le != "+Inf" {
+				if leVal, err := strconv.ParseFloat(le, 64); err == nil {
+					if leVal > stats.LatencyMax {
+						stats.LatencyMax = leVal
+					}
+				}
+			}
+
+		case m.Name == "bpfview_exclusion_patterns_total":
+			if typ, ok := m.Labels["pattern_type"]; ok {
+				stats.PatternCount[typ] = m.Value
+			}
+
+		case m.Name == "bpfview_excluded_event_size_bytes_sum":
+			stats.ExcludedEvents["sum"] = m.Value
+		case m.Name == "bpfview_excluded_event_size_bytes_count":
+			stats.ExcludedEvents["count"] = m.Value
+		}
+	}
+
+	// Calculate average event size
+	if sum, ok := stats.ExcludedEvents["sum"]; ok {
+		if count, ok := stats.ExcludedEvents["count"]; ok && count > 0 {
+			stats.ExcludedEvents["avg"] = sum / count
+		}
+	}
+
+	return stats
 }
 
 func contains(slice []string, item string) bool {
@@ -79,12 +387,12 @@ func printHandlerStats(handler string, metrics []MetricSample) {
 	// Get handler stats
 	var handlerCount, handlerSum float64
 	for _, m := range metrics {
-		if m.Name == "bpfview_handler_duration_seconds_count" && 
-		   m.Labels["handler"] == handler {
+		if m.Name == "bpfview_handler_duration_seconds_count" &&
+			m.Labels["handler"] == handler {
 			handlerCount = m.Value
 		}
 		if m.Name == "bpfview_handler_duration_seconds_sum" &&
-		   m.Labels["handler"] == handler {
+			m.Labels["handler"] == handler {
 			handlerSum = m.Value
 		}
 	}
@@ -101,6 +409,7 @@ func printHandlerStats(handler string, metrics []MetricSample) {
 		name       string
 		percentage float64
 		avgTime    float64
+		count      float64
 	}
 
 	phasePercentages := make(map[string]float64)
@@ -109,15 +418,15 @@ func printHandlerStats(handler string, metrics []MetricSample) {
 
 	for _, m := range metrics {
 		if m.Name == "bpfview_handler_phase_percentage" &&
-		   m.Labels["handler"] == handler {
+			m.Labels["handler"] == handler {
 			phasePercentages[m.Labels["phase"]] = m.Value
 		}
 		if m.Name == "bpfview_handler_phase_duration_seconds_sum" &&
-		   m.Labels["handler"] == handler {
+			m.Labels["handler"] == handler {
 			phaseSums[m.Labels["phase"]] = m.Value
 		}
 		if m.Name == "bpfview_handler_phase_duration_seconds_count" &&
-		   m.Labels["handler"] == handler {
+			m.Labels["handler"] == handler {
 			phaseCounts[m.Labels["phase"]] = m.Value
 		}
 	}
@@ -125,13 +434,16 @@ func printHandlerStats(handler string, metrics []MetricSample) {
 	phases := make([]phaseInfo, 0, len(phasePercentages))
 	for phase, percentage := range phasePercentages {
 		avgTime := 0.0
+		count := 0.0
 		if phaseCounts[phase] > 0 {
 			avgTime = phaseSums[phase] / phaseCounts[phase]
+			count = phaseCounts[phase]
 		}
 		phases = append(phases, phaseInfo{
 			name:       phase,
 			percentage: percentage,
 			avgTime:    avgTime,
+			count:      count,
 		})
 	}
 
@@ -145,17 +457,19 @@ func printHandlerStats(handler string, metrics []MetricSample) {
 	fmt.Printf("=====================================\n")
 	fmt.Printf("%s: avg=%.3fms (count=%.0f)\n", handler, avgHandlerTime*1000, handlerCount)
 
-	for i, phase := range phases {
-		prefix := "  ├─ "
-		if i == len(phases)-1 {
-			prefix = "  └─ "
-		}
-		fmt.Printf("%s%s: avg=%.3fms (%.1f%%)\n", 
-			prefix, 
+	// Use tabwriter for better alignment
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "  Phase\tAvg Time\tPercentage\tCount\t\n")
+	fmt.Fprintf(w, "  -----\t--------\t----------\t-----\t\n")
+	
+	for _, phase := range phases {
+		fmt.Fprintf(w, "  %s\t%.3fms\t%.1f%%\t%.0f\t\n", 
 			phase.name, 
 			phase.avgTime*1000, 
-			phase.percentage)
+			phase.percentage,
+			phase.count)
 	}
+	w.Flush()
 }
 
 func extractHandlers(metrics []MetricSample) []string {
@@ -197,7 +511,7 @@ func parseMetrics(r io.Reader) ([]MetricSample, error) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		
+
 		// Skip comments and empty lines
 		if strings.HasPrefix(line, "#") || line == "" {
 			continue
@@ -249,4 +563,8 @@ func parseMetrics(r io.Reader) ([]MetricSample, error) {
 	}
 
 	return metrics, nil
+}
+
+func clearScreen() {
+	fmt.Print("\033[H\033[2J")
 }


### PR DESCRIPTION
Add support for excluding high-volume processes from monitoring, using the following features:

- Process exclusion by command name, executable path, username, or container ID
- Tree-aware exclusions that respect --tree flag
- Pattern matching with support for exact matches, prefixes, and globs
- Early exclusion before expensive operations
- Comprehensive metrics for measuring exclusion effectiveness
- Performance analysis tool for tuning exclusions

The implementation:
- Adds exclusion engine to filter out high-volume processes
- Maintains process tree awareness when using --tree
- Adds pattern matching with support for wildcards
- Implements detailed metrics tracking
- Adds phase-stats perf tool for analyzing exclusion effectiveness

Example:
```bash
# Exclude high-volume processes
sudo bpfview --exclude-comm "nginx,php-fpm,postgres" --tree

# Analyze effectiveness
phase-stats --handler process_exec --exclusions
