### PR TITLE
Add --exclude-port to filter out high-volume network traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,19 @@ sudo bpfview --comm nginx --exclude-comm "chronyd,sshd"
 
 Exclusions are evaluated during event processing and provide a high-performance way to filter out noisy system processes. When exclusions are enabled, BPFView reports metrics about excluded processes that can be viewed via the Prometheus endpoint.
 
+### Network Exclusions
+
+BPFView supports excluding specific network traffic from monitoring, which is useful for filtering out high-volume services:
+
+```bash
+# Exclude specific ports (e.g., HTTP, HTTPS, NTP)
+sudo bpfview --exclude-port "80,443,123"
+# Combine with process exclusions
+sudo bpfview --exclude-port "80,443" --exclude-comm "chronyd"
+```
+
+Like process exclusions, network exclusions are evaluated early in event processing to efficiently filter out high-volume traffic. Metrics about excluded network events are available via the Prometheus endpoint.
+
 ## Performance Optimization
 
 BPFView is designed to operate efficiently with minimal performance impact, but can be further optimized for specific environments and high-volume workloads.

--- a/filter.go
+++ b/filter.go
@@ -29,6 +29,7 @@ type FilterConfig struct {
 	ExcludeExePath   []string
 	ExcludeUser      []string
 	ExcludeContainer []string
+	ExcludePorts     []string
 
 	// Network filters
 	SrcIPs    []string

--- a/main.go
+++ b/main.go
@@ -298,6 +298,7 @@ func main() {
 				ExePaths:     config.filterConfig.ExcludeExePath,
 				UserNames:    config.filterConfig.ExcludeUser,
 				ContainerIDs: config.filterConfig.ExcludeContainer,
+				ExcludePorts: config.filterConfig.ExcludePorts,
 			}
 			globalExcludeEngine = NewExclusionEngine(exclusionConfig, config.filterConfig.TrackTree)
 
@@ -400,6 +401,7 @@ func main() {
 	rootCmd.PersistentFlags().StringSliceVar(&config.filterConfig.ExcludeExePath, "exclude-exe-path", nil, "Exclude processes by executable path")
 	rootCmd.PersistentFlags().StringSliceVar(&config.filterConfig.ExcludeUser, "exclude-user", nil, "Exclude processes by username")
 	rootCmd.PersistentFlags().StringSliceVar(&config.filterConfig.ExcludeContainer, "exclude-container", nil, "Exclude processes by container ID")
+	rootCmd.PersistentFlags().StringSliceVar(&config.filterConfig.ExcludePorts, "exclude-port", nil, "Exclude specific ports from monitoring")
 
 	// Optional features
 	rootCmd.PersistentFlags().BoolVar(&config.HashBinaries, "hash-binaries", false, "Calculate MD5 hash of process executables")

--- a/network.go
+++ b/network.go
@@ -51,6 +51,20 @@ func handleNetworkEvent(event *types.NetworkEvent) {
 	timer.StartTiming()
 	defer timer.EndTiming()
 
+	// Add port exclusion check right at the start
+	if globalExcludeEngine != nil {
+		// Check source port
+		if _, excluded := globalExcludeEngine.excludedPorts[event.SrcPort]; excluded {
+			excludedEventsTotal.WithLabelValues("network", "port", fmt.Sprintf("%d", event.SrcPort)).Inc()
+			return
+		}
+		// Check destination port
+		if _, excluded := globalExcludeEngine.excludedPorts[event.DstPort]; excluded {
+			excludedEventsTotal.WithLabelValues("network", "port", fmt.Sprintf("%d", event.DstPort)).Inc()
+			return
+		}
+	}
+
 	// Filter check right at the start
 	timer.StartPhase("filtering")
 	if globalEngine != nil && !globalEngine.matchNetwork(event) {


### PR DESCRIPTION
- Add port-based network traffic exclusion using --exclude-port flag
- Early evaluation of port exclusions for optimal performance
- Add Prometheus metrics for excluded network events
- Update documentation to cover port exclusion feature

Example: bpfview --exclude-port "80,443,123"
