### PR TITLE
Partial fix for JA4

### DIFF
--- a/ja4.go
+++ b/ja4.go
@@ -17,11 +17,12 @@ func extractExtensions(data []byte) ([]uint16) {
 
 	//probably should do an endian test and determine which instead of just assuming big endian here.
 	//little endian
-	//helloLen := int(uint(data[6]) | uint(data[7])<<8 | uint(data[8])<<16)
+	//handshakeLen := int(uint(data[4]) | uint(data[3])<<8)
 
 	//big endian
 	handshakeLen := int(uint(data[4]) | uint(data[3])<<8)
 
+	//this is a bit of a hack due to limited data coming in from ebpf, we don't get full TLS packet, currently only 512
 	if handshakeLen > 512 {
 		return extensions
 	}
@@ -70,7 +71,6 @@ func extractExtensions(data []byte) ([]uint16) {
                 extensionsEnd = len(data)
         }
 
-	
         for offset+4 <= extensionsEnd {
                 extType := uint16(data[offset])<<8 | uint16(data[offset+1])
                 extLen := int(data[offset+2])<<8 | int(data[offset+3])

--- a/tls.go
+++ b/tls.go
@@ -265,6 +265,8 @@ func parseTCPTLS(data []byte, userEvent *types.UserSpaceTLSEvent) {
 		userEvent.SupportedGroups = extractSupportedGroups(data)
 		userEvent.KeyShareGroups = extractKeyShareGroups(data)
 		userEvent.ALPNValues = extractALPN(data)
+		userEvent.Extensions = extractExtensions(data)
+		userEvent.SignatureAlgo = extractSignatureAlgorithms(data)
 	}
 
 	if userEvent.HandshakeType == 0x01 {

--- a/tls.go
+++ b/tls.go
@@ -261,7 +261,7 @@ func parseTCPTLS(data []byte, userEvent *types.UserSpaceTLSEvent) {
 			globalLogger.Info("tls", "Found SNI: %s", userEvent.SNI)
 		}
 		userEvent.SupportedVersions = extractSupportedVersions(data)
-		userEvent.CipherSuites = extractCipherSuites(data, 10)
+		userEvent.CipherSuites = extractCipherSuites(data, 99)
 		userEvent.SupportedGroups = extractSupportedGroups(data)
 		userEvent.KeyShareGroups = extractKeyShareGroups(data)
 		userEvent.ALPNValues = extractALPN(data)
@@ -269,7 +269,6 @@ func parseTCPTLS(data []byte, userEvent *types.UserSpaceTLSEvent) {
 
 	if userEvent.HandshakeType == 0x01 {
 		userEvent.JA4 = CalculateJA4(userEvent)
-		userEvent.JA4Hash = CalculateJA4Hash(userEvent.JA4)
 	}
 }
 
@@ -318,7 +317,6 @@ func parseQUICTLS(data []byte, userEvent *types.UserSpaceTLSEvent) {
 				packetType,
 				strings.ReplaceAll(userEvent.SNI, ".", "d"),
 				userEvent.QUICVersion)
-			userEvent.JA4Hash = CalculateJA4Hash(userEvent.JA4)
 		}
 	}
 }

--- a/types/events.go
+++ b/types/events.go
@@ -219,7 +219,7 @@ type UserSpaceTLSEvent struct {
 	SupportedGroups   []uint16
 	KeyShareGroups    []uint16
 	ALPNValues        []string
-	Extensions        []string
+	Extensions        []uint16
 	JA4               string
 	JA4Hash           string
 	IsQUIC            bool // Helper field to identify QUIC connections

--- a/types/events.go
+++ b/types/events.go
@@ -219,6 +219,7 @@ type UserSpaceTLSEvent struct {
 	SupportedGroups   []uint16
 	KeyShareGroups    []uint16
 	ALPNValues        []string
+	Extensions        []string
 	JA4               string
 	JA4Hash           string
 	IsQUIC            bool // Helper field to identify QUIC connections

--- a/types/events.go
+++ b/types/events.go
@@ -220,6 +220,7 @@ type UserSpaceTLSEvent struct {
 	KeyShareGroups    []uint16
 	ALPNValues        []string
 	Extensions        []uint16
+	SignatureAlgo	  []uint16
 	JA4               string
 	JA4Hash           string
 	IsQUIC            bool // Helper field to identify QUIC connections


### PR DESCRIPTION
This only partially fixes JA4 fingerprinting.  There are some we have to skip due to ebpf limitations and even with my attempt to mitigate that, I'm still missing pulling the last extension in some of these, so the fingerprint is incorrect in some cases, but wanted to get this potentially merged before you pushed forward with other changes.