### PR TITLE
Add vector embeddings to process data in SQLite formatter

### DIFF
--- a/outputformats/go.mod
+++ b/outputformats/go.mod
@@ -5,7 +5,8 @@ go 1.24.1
 replace github.com/tursodatabase/limbo => github.com/jnesss/limbo/bindings/go v0.0.0-20250503230926-aee6259310b1
 
 require (
-	github.com/jnesss/bpfview/types v0.0.0-20250410184514-307cf1204dd8
+	github.com/jnesss/bpfview/fingerprint v0.0.0-20250505202533-00261f99d622
+	github.com/jnesss/bpfview/types v0.0.0-20250425142618-5589dc619074
 	github.com/tursodatabase/limbo v0.0.0-00010101000000-000000000000
 )
 

--- a/outputformats/go.mod
+++ b/outputformats/go.mod
@@ -2,10 +2,14 @@ module github.com/jnesss/bpfview/outputformats
 
 go 1.24.1
 
+replace github.com/jnesss/bpfview/fingerprint => ../fingerprint
+
+replace github.com/jnesss/bpfview/types => ../types
+
 replace github.com/tursodatabase/limbo => github.com/jnesss/limbo/bindings/go v0.0.0-20250503230926-aee6259310b1
 
 require (
-	github.com/jnesss/bpfview/fingerprint v0.0.0-20250505202533-00261f99d622
+	github.com/jnesss/bpfview/fingerprint v0.0.0-00010101000000-000000000000
 	github.com/jnesss/bpfview/types v0.0.0-20250425142618-5589dc619074
 	github.com/tursodatabase/limbo v0.0.0-00010101000000-000000000000
 )

--- a/outputformats/go.sum
+++ b/outputformats/go.sum
@@ -1,7 +1,9 @@
 github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
 github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/jnesss/bpfview/types v0.0.0-20250410184514-307cf1204dd8 h1:ZTHHJ5rlwErlj/EvkSQgpfRpDJAAM+H2izIaoJgJFdg=
-github.com/jnesss/bpfview/types v0.0.0-20250410184514-307cf1204dd8/go.mod h1:jItmOCpiPJZHC36V5XLFiEUQtT4p/EUUiU0gj9Q/kQU=
+github.com/jnesss/bpfview/fingerprint v0.0.0-20250505202533-00261f99d622 h1:6/AZZl7Pe3dEDUM2MUMCHBpHx1+dmFCHkEdnDF4kSoI=
+github.com/jnesss/bpfview/fingerprint v0.0.0-20250505202533-00261f99d622/go.mod h1:kqaZXXV7Wdj2ge1k3jkfGDRAYfK0T8JaNBxKt2nhszw=
+github.com/jnesss/bpfview/types v0.0.0-20250425142618-5589dc619074 h1:YnBbOeF45w84f+ZB5AyDiYzhX9K9cucIdUDkP+sdU+k=
+github.com/jnesss/bpfview/types v0.0.0-20250425142618-5589dc619074/go.mod h1:jItmOCpiPJZHC36V5XLFiEUQtT4p/EUUiU0gj9Q/kQU=
 github.com/jnesss/limbo/bindings/go v0.0.0-20250503230926-aee6259310b1 h1:6S2FcQEQqK5e/uJaM6FHGB3yDXtUBedu+v0jw/fSYTU=
 github.com/jnesss/limbo/bindings/go v0.0.0-20250503230926-aee6259310b1/go.mod h1:kp0ZohhMPriwwhf0Uq9Y1Y5tfWQ6yZRwt1boq5aS7DA=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=


### PR DESCRIPTION
This PR adds support for storing vector embeddings in the SQLite/Limbo database format. 

Two vector embeddings are now generated and stored for each process:

1. proc_embedding (64D): Captures process behavior characteristics including command line patterns, working directory type, event type, and parent relationship

2. context_embedding (32D): Captures temporal and user context of the process such as time of day, day of week, user type, and container status

With these embeddings we can do similar searching and behavior clustering for process activity.  The implementation uses Limbo's F32_BLOB column type with the vector() SQL function to properly store the embedding data.