### PR TITLE
Integrate binary analysis features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,55 @@
+# Compiled binaries and executables
+/main
+/bpfview
+
+# Generated BPF files
+*.o
+
+# Database files
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+binarymetadata.db*
+
+# Log files
+/logs/
+*.log
+
+# Generated Go files from BPF
+*_bpfeb.go
+*_bpfel.go
+*.skel.go
+
+# IDE and editor specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Test data and temp files
+/testdata/
+/tmp/
+*.tmp
+*.bak
+
+# Environment files
+.env
+.env.local
+.envrc
+
+# Dependency directories
+node_modules/
+
+# System
+.nfs*
+.fuse_hidden*
+
+# Debug info
+/debug
+/coverage.txt
+/profile.out
+/cpu.prof
+/mem.prof

--- a/binaryanalyzer/interfaces.go
+++ b/binaryanalyzer/interfaces.go
@@ -16,6 +16,9 @@ type BinaryAnalyzer interface {
 	// Get metadata for a binary by path
 	GetMetadataByPath(path string) (BinaryMetadata, bool)
 
+	// Set a callback function that will be called when a new binary is analyzed
+	SetNewBinaryCallback(func(BinaryMetadata))
+
 	// Close and clean up resources
 	Close() error
 }

--- a/metrics.go
+++ b/metrics.go
@@ -47,6 +47,34 @@ var (
 		},
 		[]string{"event_type", "operation", "result"},
 	)
+
+	// Binary metrics
+	binarySeenTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "bpfview_binary_seen_total",
+			Help: "Total number of unique binaries seen",
+		})
+
+	binaryTypeCount = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bpfview_binary_type_count",
+			Help: "Number of binaries by type",
+		},
+		[]string{"elf_type"})
+
+	binaryArchCount = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bpfview_binary_arch_count",
+			Help: "Number of binaries by architecture",
+		},
+		[]string{"architecture"})
+
+	binaryPackageCount = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bpfview_binary_package_count",
+			Help: "Number of binaries by package source",
+		},
+		[]string{"package"})
 )
 
 // Proc reads counter

--- a/outputformats/formatter.go
+++ b/outputformats/formatter.go
@@ -12,4 +12,5 @@ type EventFormatter interface {
 	FormatDNS(event *types.UserSpaceDNSEvent, info *types.ProcessInfo) error
 	FormatTLS(event *types.UserSpaceTLSEvent, info *types.ProcessInfo) error
 	FormatSigmaMatch(match *types.SigmaMatch) error
+	FormatBinary(binary *types.BinaryInfo) error
 }

--- a/types/events.go
+++ b/types/events.go
@@ -248,3 +248,37 @@ type SigmaMatch struct {
 	DetectionSource string // "dns_query" or "network_connection" or "process_creation"
 	ResponseActions []string
 }
+
+// BinaryInfo represents information about a binary file
+type BinaryInfo struct {
+	Path       string
+	MD5Hash    string
+	SHA256Hash string
+	FileSize   int64
+	ModTime    time.Time
+	FirstSeen  time.Time
+
+	// ELF-specific information
+	IsELF              bool
+	ELFType            string
+	Architecture       string
+	Interpreter        string
+	ImportedLibraries  []string
+	ImportCount        int
+	ExportCount        int
+	IsStaticallyLinked bool
+	Sections           []string
+	HasDebugInfo       bool
+
+	// Package information
+	IsFromPackage  bool
+	PackageName    string
+	PackageVersion string
+
+	// Process context
+	ProcessUID string
+	PID        uint32
+	PPID       uint32
+	Comm       string
+	ParentComm string
+}


### PR DESCRIPTION
Integrates the binary analyzer component with BPFView's output formatters.  This change allows BPFView to collect, analyze, and log detailed metadata about binary files executed on the system.

Key changes:
- Added callback mechanism to binaryanalyzer package
- Implemented FormatBinary method for all output formatters
- Added binary_events table to SQLite schema
- Added binary-specific fields to JSON, text, and other formatters

Limitations/Known issues:
- No process-binary association yet
- Package verification not yet implemented
